### PR TITLE
JI-5464 return null fields for empty state

### DIFF
--- a/scripts/essay.js
+++ b/scripts/essay.js
@@ -1064,9 +1064,12 @@ H5P.Essay = function ($, Question) {
     }
 
     const inputFieldText = this.inputField.getText();
+    if (!inputFieldText) {
+      return;
+    }
     return {
-      inputField: inputFieldText || null,
-      viewState: inputFieldText ? this.viewState : null
+      inputField: inputFieldText,
+      viewState: this.viewState
     };
   };
 

--- a/scripts/essay.js
+++ b/scripts/essay.js
@@ -1063,9 +1063,10 @@ H5P.Essay = function ($, Question) {
       this.inputField.updateMessageSaved(this.params.messageSave);
     }
 
+    const inputFieldText = this.inputField.getText();
     return {
-      inputField: this.inputField.getText(),
-      viewState: this.viewState
+      inputField: inputFieldText || null,
+      viewState: inputFieldText ? this.viewState : null
     };
   };
 


### PR DESCRIPTION
This will return null for empty saved states so that the h5p core library will no longer incorrectly show the "Your progress was restored" message.
Without this change the progress restored message is incorrectly shown on h5p.com instances when the user enters no data and refreshes the page.